### PR TITLE
app.properties和server.properties配置属性支持放入application.properties

### DIFF
--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/core/ConfigConsts.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/core/ConfigConsts.java
@@ -9,4 +9,5 @@ public interface ConfigConsts {
   String CONFIG_FILE_CONTENT_KEY = "content";
   String NO_APPID_PLACEHOLDER = "ApolloNoAppIdPlaceHolder";
   long NOTIFICATION_ID_PLACEHOLDER = -1;
+  String APPLICATION_CLASSPATH = "/application.properties";
 }

--- a/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/foundation/internals/provider/DefaultApplicationProvider.java
@@ -1,21 +1,23 @@
 package com.ctrip.framework.foundation.internals.provider;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.Properties;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.ctrip.framework.apollo.core.ConfigConsts;
 import com.ctrip.framework.foundation.internals.Utils;
 import com.ctrip.framework.foundation.internals.io.BOMInputStream;
 import com.ctrip.framework.foundation.spi.provider.ApplicationProvider;
 import com.ctrip.framework.foundation.spi.provider.Provider;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultApplicationProvider implements ApplicationProvider {
   private static final Logger logger = LoggerFactory.getLogger(DefaultApplicationProvider.class);
   public static final String APP_PROPERTIES_CLASSPATH = "/META-INF/app.properties";
+
+  private static String PROPERTIES_PATH = APP_PROPERTIES_CLASSPATH;
+
   private Properties m_appProperties = new Properties();
 
   private String m_appId;
@@ -26,6 +28,13 @@ public class DefaultApplicationProvider implements ApplicationProvider {
       InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(APP_PROPERTIES_CLASSPATH);
       if (in == null) {
         in = DefaultApplicationProvider.class.getResourceAsStream(APP_PROPERTIES_CLASSPATH);
+      }
+      if(in == null){
+        in = Thread.currentThread().getContextClassLoader().getResourceAsStream(ConfigConsts.APPLICATION_CLASSPATH);
+        if (in == null) {
+          in = DefaultApplicationProvider.class.getResourceAsStream(ConfigConsts.APPLICATION_CLASSPATH);
+        }
+        PROPERTIES_PATH = ConfigConsts.APPLICATION_CLASSPATH;
       }
 
       initialize(in);
@@ -98,12 +107,12 @@ public class DefaultApplicationProvider implements ApplicationProvider {
     m_appId = m_appProperties.getProperty("app.id");
     if (!Utils.isBlank(m_appId)) {
       m_appId = m_appId.trim();
-      logger.info("App ID is set to {} by app.id property from {}", m_appId, APP_PROPERTIES_CLASSPATH);
+      logger.info("App ID is set to {} by app.id property from {}", m_appId, PROPERTIES_PATH);
       return;
     }
 
     m_appId = null;
-    logger.warn("app.id is not available from System Property and {}. It is set to null", APP_PROPERTIES_CLASSPATH);
+    logger.warn("app.id is not available from System Property and {}. It is set to null", PROPERTIES_PATH);
   }
 
   @Override


### PR DESCRIPTION
Spring集成方式需增加app.properties配置文件，可以复用项目常用的application.properties文件和springboot一致